### PR TITLE
Установил no-scroll

### DIFF
--- a/src/sass/layouts/_header.scss
+++ b/src/sass/layouts/_header.scss
@@ -191,3 +191,7 @@
     display: none;
   }
 }
+
+.no-scroll {
+  overflow: hidden;
+}


### PR DESCRIPTION
В header добавил в конце .no-scroll. Его просто не было. Теперь мобильное меню не скролится.