### PR TITLE
Fix иконок

### DIFF
--- a/src/sass/layouts/_footer.scss
+++ b/src/sass/layouts/_footer.scss
@@ -7,15 +7,14 @@
     padding-top: 60px;
   }
 
-  &__container{
+  &__container {
     padding-left: 20px;
-      padding-right: 20px;
+    padding-right: 20px;
     @include tablet {
       padding-left: 16px;
       padding-right: 16px;
     }
   }
-
 
   &__content {
     margin-bottom: 40px;
@@ -102,13 +101,21 @@
   display: flex;
   justify-content: flex-end;
   gap: 28px;
-  width: 156px;
   margin-bottom: 40px;
   margin-left: auto;
 
+  @include tablet {
+    gap: 30px;
+  }
+
   &__item {
     height: 32px;
-    flex-basis: calc((100% - 60px) / 3);
+    width: 32px;
+
+    @include tablet {
+      height: 34px;
+      width: 34px;
+    }
   }
 
   &__link {
@@ -119,7 +126,7 @@
     width: 100%;
     height: 100%;
     border-radius: 50%;
- 
+
     transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1);
 
     &:hover,


### PR DESCRIPTION
Не заметил, что на таблет и десктопе иконки чуть больше. Убрал фиксированную ширину контейнера для иконок. Gap в этом случае всё решает. Нет необходимости вычислять ширину иконок, так как в этом случае нужно менять ширину контейнера. Это только усложняет решение.